### PR TITLE
Add rpcbind as client service to map.jinja for Debian

### DIFF
--- a/nfs/map.jinja
+++ b/nfs/map.jinja
@@ -9,7 +9,7 @@
         'pkgs_server': ['nfs-common', 'nfs-kernel-server'],
         'pkgs_client': ['nfs-common'],
         'service_server': 'nfs-kernel-server',
-        'service_client': False,
+        'service_client': 'rpcbind',
     },
     'FreeBSD': {
         'pkgs_client': False,


### PR DESCRIPTION
At least for Debian Jessie it looks like it is required that the `rpcbind`
service is running for the client as well.
